### PR TITLE
fix(setup): make script award of its location

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,7 @@ runs:
       env:
         INPUT_DRYRUN: ${{ inputs.dry-run }}
         INPUT_WITHOUTPREFIX: ${{ inputs.without-prefix }}
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
     - name: Semantic Release
       uses: cycjimmy/semantic-release-action@v2
       with:

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [ -z "$GITHUB_ACTION_PATH" ]; then
+  GITHUB_ACTION_PATH=.
+fi
+
 echo "+ Create package.json file"
 echo '{"description": "","private": true,"version": "0.0.0","release":{}}' >package.json
 # shellcheck disable=SC2094
@@ -12,7 +16,7 @@ if [ "${INPUT_DRYRUN}" == "true" ]; then
 else
   echo "+ Setup releasable branches"
   # shellcheck disable=SC2094
-  cat <<<"$(jq --argjson branches "$(<branches.json)" '.release += {branches: $branches}' package.json)" >package.json
+  cat <<<"$(jq --argjson branches "$(<${GITHUB_ACTION_PATH}/branches.json)" '.release += {branches: $branches}' package.json)" >package.json
 fi
 
 if [ "${INPUT_WITHOUTPREFIX}" == "true" ]; then


### PR DESCRIPTION
To enable `setup.sh` script to access to `branches.json` file