### PR TITLE
build: use codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @rlespinasse

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,23 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/.github/"
+  - package-ecosystem: 'github-actions'
+    directory: '/.github/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       dependencies:
         patterns:
-            - "*"
-    reviewers:
-      - "rlespinasse"
-    labels: [ ]
-  - package-ecosystem: "github-actions"
-    directory: "/"
+          - '*'
+    labels: []
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     commit-message:
-      prefix: "feat: "
+      prefix: 'feat: '
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       dependencies:
         patterns:
-          - "rlespinasse/github-slug-action"
-          - "cycjimmy/semantic-release-action"
-    reviewers:
-      - "rlespinasse"
-    labels: [ ]
+          - 'rlespinasse/github-slug-action'
+          - 'cycjimmy/semantic-release-action'
+    labels: []

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -25,4 +25,5 @@ jobs:
         uses: super-linter/super-linter@v7
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_YAML_PRETTIER: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/